### PR TITLE
Add more descriptive error handling to file registration

### DIFF
--- a/upload_swift_notify_cube.py
+++ b/upload_swift_notify_cube.py
@@ -7,6 +7,7 @@ from os import listdir, system
 from os.path import isfile, join
 
 from chrisclient import client
+from chrisclient.exceptions import ChrisRequestException
 
 parser = argparse.ArgumentParser(description='COVID-Net Training Script')
 parser.add_argument('--imageDir', default='images', type=str, help='Directory containing images to upload')
@@ -72,7 +73,7 @@ for index in range(len(dcmFiles)):
       }
       try:
         chris_client.register_pacs_file(pacs_data)
-      except:
-        print('Already Registered: {}'.format(f[1]))
+      except ChrisRequestException as e:
+        print(f"{f[1]}: {e}")
         continue
       print('SUCCESS')


### PR DESCRIPTION
Current output
![image](https://user-images.githubusercontent.com/53355975/120822243-36928a80-c524-11eb-9b47-6c9762585ddf.png)

Proposed output 
![image](https://user-images.githubusercontent.com/53355975/120822303-46aa6a00-c524-11eb-81b1-ecb877780ca4.png)
While it looks different visually, it also takes into consideration not being able to find the file path in Swift and other possible errors, instead of just returning "Already Registered" all the time.